### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,7 @@ const readLabels = labelingInfo => {
     let labelStyle = readSymbol(labelDefinition.symbol);
     labelStyle.maxScale = labelDefinition.minScale || 1000;
     labelStyle.minScale = labelDefinition.maxScale || 0;
+    labelDefinition.labelExpression = || "";
     labelStyle.text = labelDefinition.labelExpression
       .replace(/\[/g, '{')
       .replace(/\]/g, '}')


### PR DESCRIPTION
If a label expression is undefined or null, an error is thrown.  
Setting a default value prevents this error.